### PR TITLE
Agregando ModelMapperConfig

### DIFF
--- a/src/main/java/com/unla/utilizandoSpring/configuration/ModelMapperConfig.java
+++ b/src/main/java/com/unla/utilizandoSpring/configuration/ModelMapperConfig.java
@@ -1,0 +1,42 @@
+package com.unla.utilizandoSpring.configuration;
+
+import com.unla.utilizandoSpring.dtos.DegreeDTO;
+import com.unla.utilizandoSpring.entities.Degree;
+
+import org.modelmapper.ModelMapper;
+import org.modelmapper.PropertyMap;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+
+	@Bean
+	ModelMapper modelMapper() {
+
+		ModelMapper mapper = new ModelMapper();
+
+		// DTO --> Entity
+		PropertyMap<DegreeDTO, Degree> dtoToEntityMAp = new PropertyMap<>() {
+			@Override
+			protected void configure() {
+				map().setInstitution(source.getInstitucion());
+			}
+		};
+
+		// Entity to DTO
+		PropertyMap<Degree, DegreeDTO> entityToDtoMap = new PropertyMap<>() {
+			@Override
+			protected void configure() {
+				map().setInstitucion(source.getInstitution());
+			}
+		};
+
+		mapper.addMappings(dtoToEntityMAp);
+		mapper.addMappings(entityToDtoMap);
+
+		return mapper;
+
+	}
+
+}

--- a/src/main/java/com/unla/utilizandoSpring/service/implemantation/DegreeService.java
+++ b/src/main/java/com/unla/utilizandoSpring/service/implemantation/DegreeService.java
@@ -17,12 +17,13 @@ public class DegreeService implements IDegreeService {
 	// Declara el atributo que sera inyectado por Spring en tiempo de ejecucion
 	private IDegreeRepository degreeRepository;
 	
-	// // Inyecta una implemantacion del bean llamado degreeRepository que impleneta la interfaz IDegreeRepository
-	public DegreeService(@Qualifier("degreeRepository") IDegreeRepository degreeRepository) {
-		this.degreeRepository = degreeRepository;
-	}
+	private ModelMapper modelMapper;
 	
-	private ModelMapper modelMapper = new ModelMapper();
+	// // Inyecta una implemantacion del bean llamado degreeRepository que impleneta la interfaz IDegreeRepository
+	public DegreeService(@Qualifier("degreeRepository") IDegreeRepository degreeRepository,ModelMapper modelMApper) {
+		this.degreeRepository = degreeRepository;
+		this.modelMapper = modelMApper;
+	}
 	
 	@Override
 	public List<Degree> getAll(){


### PR DESCRIPTION
SUMMARY
Agregando mapeos personalizados, para campos con diferenctes nombres, centralizando la configuracion de ModelMapper en una clase de configuración.